### PR TITLE
Very minor update to skull rotation javadoc

### DIFF
--- a/src/main/java/org/bukkit/block/Skull.java
+++ b/src/main/java/org/bukkit/block/Skull.java
@@ -30,14 +30,14 @@ public interface Skull extends BlockState {
     public boolean setOwner(String name);
 
     /**
-     * Gets the rotation of the skull
+     * Gets the rotation of the skull in the world
      *
      * @return the rotation of the skull
      */
     public BlockFace getRotation();
 
     /**
-     * Sets the rotation of the skull
+     * Sets the rotation of the skull in the world
      *
      * @param rotation the rotation of the skull
      */


### PR DESCRIPTION
This pull request does only one thing: it adds "in the world" to "rotation of the skull" to make it a bit clearer to those who could've interpreted it to mean something else.
