### PR TITLE
Fix the Combuster

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityCombustByEntityEvent.java
@@ -11,7 +11,7 @@ public class EntityCombustByEntityEvent extends EntityCombustEvent {
     }
 
     /**
-     * The combuster can be a WeatherStorm a Blaze, or an Entity holding a FIRE_ASPECT enchanted item.
+     * Get the entity that caused the combustion event.
      *
      * @return the Entity that set the combustee alight.
      */


### PR DESCRIPTION
The list was horribly formatted and out-of-date. No reason to list every possible entity that could set another entity on fire.
