### PR TITLE
Updated documentation for setFullTime(long)

### DIFF
--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -470,6 +470,8 @@ public interface World extends PluginMessageRecipient, Metadatable {
 
     /**
      * Sets the full in-game time on this world
+     * <p>
+     * Note that setting the time backwards may cause adverse effects such as breaking redstone clocks and any scheduled tasks.
      *
      * @param time The new absolute time to set this world to
      * @see #setTime(long) Sets the relative time of this world

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -469,10 +469,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
     public long getFullTime();
 
     /**
-     * Sets the in-game time on the server
-     * <p>
-     * Note that this sets the full time of the world, which may cause adverse
-     * effects such as breaking redstone clocks and any scheduled events
+     * Sets the full in-game time on this world
      *
      * @param time The new absolute time to set this world to
      * @see #setTime(long) Sets the relative time of this world

--- a/src/main/java/org/bukkit/World.java
+++ b/src/main/java/org/bukkit/World.java
@@ -471,7 +471,8 @@ public interface World extends PluginMessageRecipient, Metadatable {
     /**
      * Sets the full in-game time on this world
      * <p>
-     * Note that setting the time backwards may cause adverse effects such as breaking redstone clocks and any scheduled tasks.
+     * Note that setting the time backwards may cause adverse
+     * effects such as breaking redstone clocks and any scheduled tasks.
      *
      * @param time The new absolute time to set this world to
      * @see #setTime(long) Sets the relative time of this world


### PR DESCRIPTION
setTime(long) is implemented using setFullTime(long).  As long as the latter is not used to set the time to a point in the past, it should be as safe to use as the former.  I'm uncertain as to what would happen if time were rewound, so I've adapted the advisory for that case.
