### PR TITLE
Javadoc for ItemDespawnEvent

### DIFF
--- a/src/main/java/org/bukkit/event/entity/ItemDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemDespawnEvent.java
@@ -5,6 +5,12 @@ import org.bukkit.entity.Item;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
+/**
+ * This event is called when a {@link org.bukkit.entity.Item} is removed from
+ * the world because it has existed for 5 minutes. Cancelling the event
+ * results in the item being allowed to exist for 5 more minutes. This
+ * behavior is not guaranteed and may change in future versions.
+ */
 public class ItemDespawnEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     private boolean canceled;

--- a/src/main/java/org/bukkit/material/Step.java
+++ b/src/main/java/org/bukkit/material/Step.java
@@ -17,6 +17,8 @@ public class Step extends TexturedMaterial {
         textures.add(Material.COBBLESTONE);
         textures.add(Material.BRICK);
         textures.add(Material.SMOOTH_BRICK);
+        textures.add(Material.NETHER_BRICK);
+        textures.add(Material.QUARTZ_BLOCK);
     }
 
     public Step() {


### PR DESCRIPTION
- Reveals 5-minute threshold, which cannot currently be changed by any API method
- **Explains cancellation behavior**
- Disclaims future behavior
- I'm not sure why the recent Bukkit commit is showing up on top
