### PR TITLE
Add javadoc to ItemDespawnEvent

### DIFF
--- a/src/main/java/org/bukkit/event/entity/ItemDespawnEvent.java
+++ b/src/main/java/org/bukkit/event/entity/ItemDespawnEvent.java
@@ -6,7 +6,11 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Called when an item de-spawns from the world.
+ * This event is called when a {@link org.bukkit.entity.Item} is removed from
+ * the world because it has existed for 5 minutes.
+ * <p>
+ * Cancelling the event results in the item being allowed to exist for 5 more
+ * minutes. This behavior is not guaranteed and may change in future versions.
  */
 public class ItemDespawnEvent extends EntityEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
- Reveals 5-minute threshold, which cannot currently be changed by any API method
- **Explains cancellation behavior**
- Disclaims future behavior
- Is now on the correct branch
