### PR TITLE
Expand javadocs for all 3 command pre-processing events

### DIFF
--- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
@@ -10,8 +10,8 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * This event is called whenever a player runs a command (by placing a slash at
- * the start of their message). It is called early in the command handling
+ * This event is called whenever a player runs a command (by placing a slash
+ * at the start of their message). It is called early in the command handling
  * process, and modifications in this event (via {@link #setMessage(String)})
  * will be shown in the behavior.
  * <p>
@@ -20,26 +20,26 @@ import org.bukkit.event.HandlerList;
  * <p>
  * Some examples of valid uses for this event are:
  * <ul>
- * <li>Logging executed commands to a separate file</li>
- * <li>Variable substitution (for example, replacing "
- * <code>${nearbyPlayer}</code>" with the name of the nearest other player)</li>
- * <li>Conditionally blocking commands belonging to other plugins (for example,
- * you may not use <code>/home</code> in the combat arena)</li>
- * <li>Per-sender command aliases (for example, after a player the 'calias'
- * command for 'cr' -> 'gamemode creative', start replacing <code>/cr</code>
- * with <code>/gamemode creative</code>).</li>
+ * <li>Logging executed commands to a separate file
+ * <li>Variable substitution (for example, replacing ' ${nearbyPlayer}' with
+ * the name of the nearest other player)
+ * <li>Conditionally blocking commands belonging to other plugins (for
+ * example, you may not use the '/home' command in the combat arena)
+ * <li>Per-sender command aliases (for example, after a player runs the
+ * 'calias' command for 'cr' -> 'gamemode creative', start replacing '/cr'
+ * with '/gamemode creative').
  * </ul>
  * <p>
  * Examples of incorrect uses are:
  * <ul>
- * <li>Using this event to run command logic</li>
+ * <li>Using this event to run command logic
  * </ul>
  * <p>
  * If the event is cancelled, processing of the command will halt.
  * <p>
- * The state of whether or not there is a slash at the beginning of the message
- * should be preserved. If a slash is added or removed, unexpected behavior may
- * result.
+ * The state of whether or not there is a slash (<code>/</code>) at the
+ * beginning of the message should be preserved. If a slash is added or
+ * removed, unexpected behavior may result.
  */
 public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
@@ -10,8 +10,36 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
 
 /**
- * Called early in the command handling process. This event is only
- * for very exceptional cases and you should not normally use it.
+ * This event is called whenever a player runs a command (by placing a slash at
+ * the start of their message). It is called early in the command handling
+ * process, and modifications in this event (via {@link #setMessage(String)})
+ * will be shown in the behavior.
+ * <p>
+ * Many plugins will have <b>no use for this event</b>, and you should attempt
+ * to avoid using it if it is not necessary.
+ * <p>
+ * Some examples of valid uses for this event are:
+ * <ul>
+ * <li>Logging executed commands to a separate file</li>
+ * <li>Variable substitution (for example, replacing "
+ * <code>${nearbyPlayer}</code>" with the name of the nearest other player)</li>
+ * <li>Conditionally blocking commands belonging to other plugins (for example,
+ * you may not use <code>/home</code> in the combat arena)</li>
+ * <li>Per-sender command aliases (for example, after a player the 'calias'
+ * command for 'cr' -> 'gamemode creative', start replacing <code>/cr</code>
+ * with <code>/gamemode creative</code>).</li>
+ * </ul>
+ * <p>
+ * Examples of incorrect uses are:
+ * <ul>
+ * <li>Using this event to run command logic</li>
+ * </ul>
+ * <p>
+ * If the event is cancelled, processing of the command will halt.
+ * <p>
+ * The state of whether or not there is a slash at the beginning of the message
+ * should be preserved. If a slash is added or removed, unexpected behavior may
+ * result.
  */
 public class PlayerCommandPreprocessEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
+++ b/src/main/java/org/bukkit/event/player/PlayerCommandPreprocessEvent.java
@@ -15,19 +15,24 @@ import org.bukkit.event.HandlerList;
  * process, and modifications in this event (via {@link #setMessage(String)})
  * will be shown in the behavior.
  * <p>
- * Many plugins will have <b>no use for this event</b>, and you should attempt
- * to avoid using it if it is not necessary.
+ * Many plugins will have <b>no use for this event</b>, and you should
+ * attempt to avoid using it if it is not necessary.
  * <p>
  * Some examples of valid uses for this event are:
  * <ul>
  * <li>Logging executed commands to a separate file
- * <li>Variable substitution (for example, replacing ' ${nearbyPlayer}' with
- * the name of the nearest other player)
- * <li>Conditionally blocking commands belonging to other plugins (for
- * example, you may not use the '/home' command in the combat arena)
- * <li>Per-sender command aliases (for example, after a player runs the
- * 'calias' command for 'cr' -> 'gamemode creative', start replacing '/cr'
- * with '/gamemode creative').
+ * <li>Variable substitution. For example, replacing
+ *     <code>${nearbyPlayer}</code> with the name of the nearest other
+ *     player, or simulating the <code>@a</code> and <code>@p</code>
+ *     decorators used by Command Blocks in plugins that do not handle it.
+ * <li>Conditionally blocking commands belonging to other plugins. For
+ *     example, blocking the use of the <code>/home</code> command in a
+ *     combat arena.
+ * <li>Per-sender command aliases. For example, after a player runs the
+ *     command <code>/calias cr gamemode creative</code>, the next time they
+ *     run <code>/cr</code>, it gets replaced into
+ *     <code>/gamemode creative</code>. (Global command aliases should be
+ *     done by registering the alias.)
  * </ul>
  * <p>
  * Examples of incorrect uses are:

--- a/src/main/java/org/bukkit/event/server/RemoteServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/RemoteServerCommandEvent.java
@@ -4,7 +4,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 
 /**
- * Remote Server Command events
+ * This event is called when a command is recieved over RCON. See the javadocs
+ * of {@link ServerCommandEvent} for more information.
  */
 public class RemoteServerCommandEvent extends ServerCommandEvent {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
@@ -8,19 +8,22 @@ import org.bukkit.event.HandlerList;
  * called early in the command handling process, and modifications in this
  * event (via {@link #setCommand(String)}) will be shown in the behavior.
  * <p>
- * Many plugins will have <b>no use for this event</b>, and you should attempt
- * to avoid using it if it is not necessary.
+ * Many plugins will have <b>no use for this event</b>, and you should
+ * attempt to avoid using it if it is not necessary.
  * <p>
  * Some examples of valid uses for this event are:
  * <ul>
  * <li>Logging executed commands to a separate file
- * <li>Variable substitution (for example, replacing '${ip:Steve}' with the
- * connection IP of the player named Steve)
- * <li>Conditionally blocking commands belonging to other plugins (for
- * example, you may not use the '/home' command in the combat arena)
- * <li>Per-sender command aliases (for example, after the console runs '
- * calias cr gamemode creative', start replacing a command of ' cr' with
- * 'gamemode creative').
+ * <li>Variable substitution. For example, replacing <code>${ip:Steve}</code>
+ *     with the connection IP of the player named Steve, or simulating the
+ *     <code>@a</code> and <code>@p</code> decorators used by Command Blocks
+ *     for plugins that do not handle it.
+ * <li>Conditionally blocking commands belonging to other plugins.
+ * <li>Per-sender command aliases. For example, after the console runs the
+ *     command <code>/calias cr gamemode creative</code>, the next time they
+ *     run <code>/cr</code>, it gets replaced into
+ *     <code>/gamemode creative</code>. (Global command aliases should be
+ *     done by registering the alias.)
  * </ul>
  * <p>
  * Examples of incorrect uses are:

--- a/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
@@ -4,7 +4,35 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 
 /**
- * Server Command events
+ * This event is called when a command is run from the server console. It is
+ * called early in the command handling process, and modifications in this event
+ * (via {@link #setCommand(String)}) will be shown in the behavior.
+ * <p>
+ * Many plugins will have <b>no use for this event</b>, and you should attempt
+ * to avoid using it if it is not necessary.
+ * <p>
+ * Some examples of valid uses for this event are:
+ * <ul>
+ * <li>Logging executed commands to a separate file</li>
+ * <li>Variable substitution (for example, replacing "<code>${ip:Steve}</code>"
+ * with the connection IP of the player named Steve)</li>
+ * <li>Conditionally blocking commands belonging to other plugins (for example,
+ * you may not use <code>/home</code> in the combat arena)</li>
+ * <li>Per-sender command aliases (for example, after the console runs '
+ * <code>calias cr gamemode creative</code>', start replacing a command of '
+ * <code>cr</code>' with '<code>gamemode creative</code>').</li>
+ * </ul>
+ * <p>
+ * Examples of incorrect uses are:
+ * <ul>
+ * <li>Using this event to run command logic</li>
+ * </ul>
+ * <p>
+ * If the event is cancelled, processing of the command will halt.
+ * <p>
+ * The state of whether or not there is a slash at the beginning of the message
+ * should be preserved. If a slash is added or removed, unexpected behavior may
+ * result.
  */
 public class ServerCommandEvent extends ServerEvent {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
+++ b/src/main/java/org/bukkit/event/server/ServerCommandEvent.java
@@ -5,34 +5,34 @@ import org.bukkit.event.HandlerList;
 
 /**
  * This event is called when a command is run from the server console. It is
- * called early in the command handling process, and modifications in this event
- * (via {@link #setCommand(String)}) will be shown in the behavior.
+ * called early in the command handling process, and modifications in this
+ * event (via {@link #setCommand(String)}) will be shown in the behavior.
  * <p>
  * Many plugins will have <b>no use for this event</b>, and you should attempt
  * to avoid using it if it is not necessary.
  * <p>
  * Some examples of valid uses for this event are:
  * <ul>
- * <li>Logging executed commands to a separate file</li>
- * <li>Variable substitution (for example, replacing "<code>${ip:Steve}</code>"
- * with the connection IP of the player named Steve)</li>
- * <li>Conditionally blocking commands belonging to other plugins (for example,
- * you may not use <code>/home</code> in the combat arena)</li>
+ * <li>Logging executed commands to a separate file
+ * <li>Variable substitution (for example, replacing '${ip:Steve}' with the
+ * connection IP of the player named Steve)
+ * <li>Conditionally blocking commands belonging to other plugins (for
+ * example, you may not use the '/home' command in the combat arena)
  * <li>Per-sender command aliases (for example, after the console runs '
- * <code>calias cr gamemode creative</code>', start replacing a command of '
- * <code>cr</code>' with '<code>gamemode creative</code>').</li>
+ * calias cr gamemode creative', start replacing a command of ' cr' with
+ * 'gamemode creative').
  * </ul>
  * <p>
  * Examples of incorrect uses are:
  * <ul>
- * <li>Using this event to run command logic</li>
+ * <li>Using this event to run command logic
  * </ul>
  * <p>
  * If the event is cancelled, processing of the command will halt.
  * <p>
- * The state of whether or not there is a slash at the beginning of the message
- * should be preserved. If a slash is added or removed, unexpected behavior may
- * result.
+ * The state of whether or not there is a slash (<code>/</code>) at the
+ * beginning of the message should be preserved. If a slash is added or
+ * removed, unexpected behavior may result.
  */
 public class ServerCommandEvent extends ServerEvent {
     private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
I fully expect to have screwed up the formatting.

Browser screenshot of the rendered javadoc page: http://i.imgur.com/m4PSqmn.png
