### PR TITLE
Reword javadocs on Inventory.contains(stack, amount) / containsAtLeast

### DIFF
--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -169,14 +169,14 @@ public interface Inventory extends Iterable<ItemStack> {
     /**
      * Checks if the inventory contains at least the minimum amount specified
      * of exactly matching ItemStacks.
-     *
+     * <p>
      * An ItemStack only counts if both the type and the amount of the stack
      * match.
      *
      * @param item The ItemStack to match against
      * @param amount How many identical stacks to check for
      * @return false if item is null, true if amount less than 1, true if
-     *         amount of exactly matching ItemStacks were found.
+     *     amount of exactly matching ItemStacks were found.
      * @see #containsAtLeast(ItemStack, int)
      */
     public boolean contains(ItemStack item, int amount);
@@ -188,7 +188,7 @@ public interface Inventory extends Iterable<ItemStack> {
      * @param item The ItemStack to match against
      * @param amount The minimum amount
      * @return false if item is null, true if amount less than 1, true if
-     *         enough ItemStacks were found to add to the given amount
+     *     enough ItemStacks were found to add to the given amount
      */
     public boolean containsAtLeast(ItemStack item, int amount);
 

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -173,8 +173,8 @@ public interface Inventory extends Iterable<ItemStack> {
      * An ItemStack only counts if both the type and the amount of the stack
      * match.
      *
-     * @param item The ItemStack to match against
-     * @param amount How many identical stacks to check for
+     * @param item the ItemStack to match against
+     * @param amount how many identical stacks to check for
      * @return false if item is null, true if amount less than 1, true if
      *     amount of exactly matching ItemStacks were found.
      * @see #containsAtLeast(ItemStack, int)
@@ -185,8 +185,8 @@ public interface Inventory extends Iterable<ItemStack> {
      * Checks if the inventory contains ItemStacks matching the given
      * ItemStack whose amounts sum to at least the minimum amount specified
      *
-     * @param item The ItemStack to match against
-     * @param amount The minimum amount
+     * @param item the ItemStack to match against
+     * @param amount the minimum amount
      * @return false if item is null, true if amount less than 1, true if
      *     enough ItemStacks were found to add to the given amount
      */

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -182,9 +182,8 @@ public interface Inventory extends Iterable<ItemStack> {
     public boolean contains(ItemStack item, int amount);
 
     /**
-     * Checks if the inventory contains any ItemStacks matching the given
-     * ItemStack in every respect except amount, and their amounts sum to at
-     * least the minimum amount specified
+     * Checks if the inventory contains ItemStacks matching the given
+     * ItemStack whose amounts sum to at least the minimum amount specified
      *
      * @param item The ItemStack to match against
      * @param amount The minimum amount

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -167,21 +167,28 @@ public interface Inventory extends Iterable<ItemStack> {
     public boolean contains(Material material, int amount) throws IllegalArgumentException;
 
     /**
-     * Checks if the inventory contains any ItemStacks matching the given ItemStack and at least the minimum amount specified
+     * Checks if the inventory contains at least the minimum amount specified
+     * of exactly matching ItemStacks, including their amounts.
+     *
      * This will only match if both the type and the amount of the stack match
      *
      * @param item The ItemStack to match against
-     * @param amount The amount of stacks to find
-     * @return false if item is null, true if amount less than 1, true if amount of exactly matching ItemStacks were found.
+     * @param amount How many identical stacks to check for
+     * @return false if item is null, true if amount less than 1, true if
+     *         amount of exactly matching ItemStacks were found.
+     * @see #containsAtLeast(ItemStack, int)
      */
     public boolean contains(ItemStack item, int amount);
 
     /**
-     * Checks if the inventory contains any ItemStacks matching the given ItemStack and at least the minimum amount specified
+     * Checks if the inventory contains any ItemStacks matching the given
+     * ItemStack in every respect except amount, and their amounts sum to at
+     * least the minimum amount specified
      *
      * @param item The ItemStack to match against
      * @param amount The minimum amount
-     * @return false if item is null, true if amount less than 1, true if enough ItemStacks were found to add to the given amount
+     * @return false if item is null, true if amount less than 1, true if
+     *         enough ItemStacks were found to add to the given amount
      */
     public boolean containsAtLeast(ItemStack item, int amount);
 

--- a/src/main/java/org/bukkit/inventory/Inventory.java
+++ b/src/main/java/org/bukkit/inventory/Inventory.java
@@ -168,9 +168,10 @@ public interface Inventory extends Iterable<ItemStack> {
 
     /**
      * Checks if the inventory contains at least the minimum amount specified
-     * of exactly matching ItemStacks, including their amounts.
+     * of exactly matching ItemStacks.
      *
-     * This will only match if both the type and the amount of the stack match
+     * An ItemStack only counts if both the type and the amount of the stack
+     * match.
      *
      * @param item The ItemStack to match against
      * @param amount How many identical stacks to check for


### PR DESCRIPTION
I performed the 78-column formatting on just the javadocs of the two methods I touched.
#### Motivation

`contains(stack,int)` counts the **number of identical stacks** (NOT the sum of their counts) while at the same time also **matching on stack amount**.
Meanwhile, containsAtLeast() counts the amounts in the stacks, which is the common case (esp. now with ItemMeta).
#### Changes
- A `@see` is added to `contains(stack, amount)` pointing to containsAtLeast().
- The wording `"exactly matching"` is added to `contains(stack, amount)` as well as moving the first mention of amount earlier in the sentence.
- The text on contains()'s @param amount is redone to be more clear.
- The 'matches amount' disclaimer is redone.
- the word 'any' ("contains any ItemStacks...") is removed from both javadocs, as we aren't looking for 'any', we're looking for 'at least'.
- 'sum to the minimum amount specified' at the end of containsAtLeast()

This is basically documenting the the implementation, but it needs to be done.
