### PR TITLE
[B+C+JD] Add Ban Reason to "Vanilla" Bukkit - Fixes BUKKIT-4285

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -29,7 +29,8 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
     public boolean isBanned();
 
     /**
-     * Bans or unbans this player
+     * Bans or unbans this player using default settings. For more settings
+     * use {@link #setBanned(boolean, String, String)}. Best for unbanning.
      *
      * @param banned true if banned
      */


### PR DESCRIPTION
**The Issue:**
Currently, there is no way to set the ban reason and banning player without using an external plugin.

**Justification:**
By having 1 less plugin to install this will increase (not by much) the server speed of many servers as they will no longer have to write to the databases that they use to store their own bans (which if they are using external servers, can become very laggy for muiltiple write requests)

**Breakdown:**
[C]This just added the required methods to keep current system working as well as new bans.
[B]This added the required changes to the ban command to parse reason and banning player.
[JD]This addresses changes to official javadoc for OfflinePlayer.setBanned

**Testing:**
Compiled server and started banning users with random reasons. Checked banned-players.txt for verification.
Also banned some with no reason to test if both options work.

**Relevant PR(s):**
https://github.com/Bukkit/CraftBukkit/pull/1250
https://github.com/Bukkit/Bukkit/pull/935
https://github.com/Bukkit/Bukkit-JavaDoc/pull/43

**JIRA Ticket:**
https://bukkit.atlassian.net/browse/BUKKIT-4813 - Closed
https://bukkit.atlassian.net/browse/BUKKIT-4285 - Not mine but suits
