### PR TITLE
Fix typo in BlockBreakEvent Javadoc

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockBreakEvent.java
@@ -14,7 +14,7 @@ import org.bukkit.event.HandlerList;
  * <li />The player is not in creative or adventure mode
  * <li />The player can loot the block (ie: does not destroy it completely, by using the correct tool)
  * <li />The player does not have silk touch
- * <li />The block drops experience in vanilla MineCraft
+ * <li />The block drops experience in vanilla Minecraft
  * </ol>
  * <p>
  * Note:


### PR DESCRIPTION
Minecraft is not spelled "MineCraft".
