### PR TITLE
[C] Added Bukkit-4835: add fire fade example to BlockFadeEvent

### DIFF
--- a/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
+++ b/src/main/java/org/bukkit/event/block/BlockFadeEvent.java
@@ -12,6 +12,7 @@ import org.bukkit.event.HandlerList;
  * <ul>
  * <li>Snow melting due to being near a light source.</li>
  * <li>Ice melting due to being near a light source.</li>
+ * <li>Fire burning out after time, without destroying fuel block.</li>
  * </ul>
  * <p>
  * If a Block Fade event is cancelled, the block will not fade, melt or disappear.


### PR DESCRIPTION
#### Description:
##### The Issue:

BlockFadeEvent was being called for fire fading (though not on inflammable blocks) but docs did not indicate such.
##### Justification for this PR:

Developers not aware of use of BlockFadeEvent on fire except by reading NMS code.
##### PR Breakdown:

Also modified javaDocs for BlockFadeEvent to add fire example.
##### Testing Results and Materials:
##### Relevant PR(s):

C-1253 - https://github.com/Bukkit/CraftBukkit/pull/1253 - adds BlockFadeEvent for inflammable blocks  
##### JIRA Ticket:

BUKKIT-4835 - https://bukkit.atlassian.net/browse/BUKKIT-4835
