### PR TITLE
Fixed spelling error in getLabel javadoc

### DIFF
--- a/src/main/java/org/bukkit/command/Command.java
+++ b/src/main/java/org/bukkit/command/Command.java
@@ -172,7 +172,7 @@ public abstract class Command {
     }
 
     /**
-     * Returns the current lable for this command
+     * Returns the current label for this command
      *
      * @return Label of this command or null if not registered
      */


### PR DESCRIPTION
"lable" corrected to "label"
