### PR TITLE
[B] Modified the wording of the second IllegalArgumentException in Player.setScoreboard. Fixes BUKKIT-5149

### DIFF
--- a/src/main/java/org/bukkit/entity/Player.java
+++ b/src/main/java/org/bukkit/entity/Player.java
@@ -703,6 +703,13 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
 
     /**
      * Sets the player's visible Scoreboard.
+     * <p>
+     * A player must always have a scoreboard set, even if it does not display
+     * anything. So in order to 'remove' a scoreboard from a player, without
+     * setting a new custom scoreboard, you must set them back to using the
+     * {@link org.bukkit.scoreboard.ScoreboardManager#getMainScoreboard() main
+     * scoreboard}.
+     * </p>
      *
      * @param scoreboard New Scoreboard for the player
      * @throws IllegalArgumentException if scoreboard is null


### PR DESCRIPTION
##### The Issue:

The description of the second IllegalArgumentException in Player.setScoreboard (http://jd.bukkit.org/dev/apidocs/org/bukkit/entity/Player.html#setScoreboard(org.bukkit.scoreboard.Scoreboard)) is ambiguous as it could be interpreted as excluding the main (vanilla) scoreboard, as this might not considered to have been "created" by the scoreboard manager.
##### Justification for this PR:

This rewording avoid the confusion of the Main (vanilla) scoreboard not being considered to have been "created" by the scoreboard manager.
##### PR Breakdown:

Changed wording of the javadocs for the second IllegalArgumentException of Player.setScoreboard method from:

IllegalArgumentException - if scoreboard was not created by the scoreboard manager

To:

IllegalArgumentException - if scoreboard was not obtained from the scoreboard manager
##### Testing Results and Materials:

N/A. Minor wording change to javadocs only.
##### Relevant PR(s):

N/A
##### JIRA Ticket:

BUKKIT-5149 - https://bukkit.atlassian.net/browse/BUKKIT-5149
