### PR TITLE
Keep it professional FIXES BUKKIT-5290

### DIFF
--- a/src/main/java/org/bukkit/event/block/Action.java
+++ b/src/main/java/org/bukkit/event/block/Action.java
@@ -19,7 +19,7 @@ public enum Action {
      */
     RIGHT_CLICK_AIR,
     /**
-     * Stepping onto or into a block (Ass-pressure)
+     * Stepping onto or into a block
      *
      * Examples:
      * <ul>


### PR DESCRIPTION
The Issue:
Its not very professional of Bukkit to have this kind of immature joke (which isn't even funny).

Justification for this PR:
As said above. This PR professionalizes the JavaDocs, just a little bit more.

https://bukkit.atlassian.net/browse/BUKKIT-5290
