### PR TITLE
Update Javadoc for EntityShootBowEvent.

### DIFF
--- a/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
+++ b/src/main/java/org/bukkit/event/entity/EntityShootBowEvent.java
@@ -30,10 +30,9 @@ public class EntityShootBowEvent extends EntityEvent implements Cancellable {
     }
 
     /**
-     * Gets the bow ItemStack used to fire the arrow; is null if the shooter
-     * is a skeleton
+     * Gets the bow ItemStack used to fire the arrow.
      *
-     * @return the bow involved in this event, or null
+     * @return the bow involved in this event
      */
     public ItemStack getBow() {
         return bow;


### PR DESCRIPTION
Skeletons now return the bow that they shot in EntityShootBowEvent, rather
than null.
