### PR TITLE
[B] Fixed javadoc warning for OfflinePlayer.setBanned

### DIFF
--- a/src/main/java/org/bukkit/OfflinePlayer.java
+++ b/src/main/java/org/bukkit/OfflinePlayer.java
@@ -32,7 +32,7 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
      * Bans or unbans this player
      *
      * @param banned true if banned
-     * @deprecated Use {@link org.bukkit.BanList#addBan(String, String, java.util.Date, String)} or {@link org.bukkit.BanList#unban(String)} to enhance functionality
+     * @deprecated Use {@link org.bukkit.BanList#addBan(String, String, java.util.Date, String)} or {@link org.bukkit.BanList#pardon(String)} to enhance functionality
      */
     @Deprecated
     public void setBanned(boolean banned);


### PR DESCRIPTION
There is no such method called BanList.unban(String).
The Method is called BanList.pardon(String)
See https://github.com/Bukkit/Bukkit/commit/75427e084d0f2a444375324b0ef7334aa66d93be#diff-972301d60a220127554416f7171487bfR50
