### PR TITLE
Update Team.java

### DIFF
--- a/src/main/java/org/bukkit/scoreboard/Team.java
+++ b/src/main/java/org/bukkit/scoreboard/Team.java
@@ -102,7 +102,7 @@ public interface Team {
     boolean canSeeFriendlyInvisibles() throws IllegalStateException;
 
     /**
-     * Sets the team's ability to see invisible {@link
+     * Sets the team's ability to see {@link
      * PotionEffectType#INVISIBILITY invisible} teammates.
      *
      * @param enabled true if invisible teammates are to be visible


### PR DESCRIPTION
The word "invisible" shows up twice when used like "invisible {@link PotionEffectType#INVISIBILITY invisible}"... one being a link and one being plain text.
