### PR TITLE
Update EventPriority.java

### DIFF
--- a/src/main/java/org/bukkit/event/EventPriority.java
+++ b/src/main/java/org/bukkit/event/EventPriority.java
@@ -15,7 +15,8 @@ public enum EventPriority {
      */
     LOW(1),
     /**
-     * Event call is neither important or unimportant, and may be ran normally
+     * Event call is neither important nor unimportant, and may be ran
+     * normally
      */
     NORMAL(2),
     /**


### PR DESCRIPTION
When using "neither", "nor" is used instead of "or".  For more: quickanddirtytips.com/education/grammar/when-use-nor
