### PR TITLE
Update ADVENTURE description

### DIFF
--- a/src/main/java/org/bukkit/GameMode.java
+++ b/src/main/java/org/bukkit/GameMode.java
@@ -23,7 +23,7 @@ public enum GameMode {
     SURVIVAL(0),
 
     /**
-     * Adventure mode cannot break blocks, use chat, use buckets, etc.
+     * Adventure mode cannot break blocks without the correct tools.
      */
     ADVENTURE(2);
 


### PR DESCRIPTION
Adventure mode only disallows the breaking of blocks without the correct tools (http://minecraft.gamepedia.com/Adventure).  This will have to soon be updated for 1.8, since no blocks will be able to be placed/destroyed, regardless of the tool.
