### PR TITLE
Complete getCurrentItem() @return description

### DIFF
--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -93,7 +93,8 @@ public class InventoryClickEvent extends InventoryInteractEvent {
     /**
      * Gets the ItemStack currently in the clicked slot.
      *
-     * @return the item in the clicked
+     * @return the item in the clicked slot. Air for empty slots, null for
+	 *     clicking outside the inventory
      */
     public ItemStack getCurrentItem() {
         if (slot_type == SlotType.OUTSIDE) {

--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -91,10 +91,10 @@ public class InventoryClickEvent extends InventoryInteractEvent {
     }
 
     /**
-     * Gets the ItemStack currently in the clicked slot.
+     * Gets the ItemStack currently in the clicked slot. Returns air for empty
+     * slots and null for clicking outside the inventory.
      *
-     * @return the item in the clicked slot. Air for empty slots, null for
-     *     clicking outside the inventory
+     * @return the item in the clicked slot
      */
     public ItemStack getCurrentItem() {
         if (slot_type == SlotType.OUTSIDE) {

--- a/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/InventoryClickEvent.java
@@ -94,7 +94,7 @@ public class InventoryClickEvent extends InventoryInteractEvent {
      * Gets the ItemStack currently in the clicked slot.
      *
      * @return the item in the clicked slot. Air for empty slots, null for
-	 *     clicking outside the inventory
+     *     clicking outside the inventory
      */
     public ItemStack getCurrentItem() {
         if (slot_type == SlotType.OUTSIDE) {


### PR DESCRIPTION
In addition to adding "slot" to "the item in the clicked", it may be helpful to state that empty slots return Air, while clicking outside the inventory returns null.  (I've tested this to confirm)
