### PR TITLE
Javadoc fixes in Conversations API

### DIFF
--- a/src/main/java/org/bukkit/conversations/Conversation.java
+++ b/src/main/java/org/bukkit/conversations/Conversation.java
@@ -31,6 +31,9 @@ import java.util.Map;
  * <p>
  * You should not construct a conversation manually. Instead, use the {@link
  * ConversationFactory} for access to all available options.
+ * <p>
+ * You should not override Conversation, as it depends on the
+ * ConversationFactory having package-level access to several methods.
  */
 public class Conversation {
 

--- a/src/main/java/org/bukkit/conversations/MessagePrompt.java
+++ b/src/main/java/org/bukkit/conversations/MessagePrompt.java
@@ -25,7 +25,7 @@ public abstract class MessagePrompt implements Prompt{
      * prompt graph instead.
      *
      * @param context Context information about the conversation.
-     * @param input Ignored.
+     * @param input Null.
      * @return The next prompt in the prompt graph.
      */
     public Prompt acceptInput(ConversationContext context, String input) {

--- a/src/main/java/org/bukkit/conversations/Prompt.java
+++ b/src/main/java/org/bukkit/conversations/Prompt.java
@@ -5,7 +5,7 @@ package org.bukkit.conversations;
  * displays text to the user and optionally waits for a user's response.
  * Prompts are chained together into a directed graph that represents the
  * conversation flow. To halt a conversation, END_OF_CONVERSATION is returned
- * in liu of another Prompt object.
+ * in lieu of another Prompt object.
  */
 public interface Prompt extends Cloneable {
 
@@ -26,6 +26,10 @@ public interface Prompt extends Cloneable {
     /**
      * Checks to see if this prompt implementation should wait for user input
      * or immediately display the next prompt.
+     * <p>
+     * If this method returns false,
+     * {@link #acceptInput(ConversationContext, String)} will be called with
+     * null as the second parameter.
      *
      * @param context Context information about the conversation.
      * @return If true, the {@link Conversation} will wait for input before
@@ -38,7 +42,7 @@ public interface Prompt extends Cloneable {
      * Prompt in the prompt graph is returned.
      *
      * @param context Context information about the conversation.
-     * @param input The input text from the user.
+     * @param input The input text from the user, or null if nonblocking.
      * @return The next Prompt in the prompt graph.
      */
     Prompt acceptInput(ConversationContext context, String input);

--- a/src/main/java/org/bukkit/conversations/Prompt.java
+++ b/src/main/java/org/bukkit/conversations/Prompt.java
@@ -27,9 +27,8 @@ public interface Prompt extends Cloneable {
      * Checks to see if this prompt implementation should wait for user input
      * or immediately display the next prompt.
      * <p>
-     * If this method returns false,
-     * {@link #acceptInput(ConversationContext, String)} will be called with
-     * null as the second parameter.
+     * If this method returns false, {@link #acceptInput(ConversationContext,
+     * String)} will be called with null as the second parameter.
      *
      * @param context Context information about the conversation.
      * @return If true, the {@link Conversation} will wait for input before


### PR DESCRIPTION
Clarify some behavior on nulls with nonblocking Prompts.
