### PR TITLE
[B] Fixes BUKKIT-5673 incorrect java doc for Location#getPitch()

### DIFF
--- a/src/main/java/org/bukkit/Location.java
+++ b/src/main/java/org/bukkit/Location.java
@@ -219,7 +219,7 @@ public class Location implements Cloneable {
     }
 
     /**
-     * Sets the pitch of this location, measured in degrees.
+     * Gets the pitch of this location, measured in degrees.
      * <ul>
      * <li>A pitch of 0 represents level forward facing.
      * <li>A pitch of 90 represents downward facing, or negative y


### PR DESCRIPTION
The issue:
The getPitch method was labeled Sets the pitch when it should be gets the pitch so that was changed.

Justification for this PR:
It would be confusing to keep this javadoc the way it is being incorrectly labeled.

PR Breakdown:
Just changed the word 'Sets' to 'Gets' as that reflects what the method does

Testing Results:
No testing needs to occur as I only changed one letter in a javadoc.

JIRA Ticket:
BUKKIT-5673 https://bukkit.atlassian.net/browse/BUKKIT-5673
